### PR TITLE
Update ImageUtil.java

### DIFF
--- a/src/main/java/com/benmu/framework/utils/ImageUtil.java
+++ b/src/main/java/com/benmu/framework/utils/ImageUtil.java
@@ -95,7 +95,7 @@ public class ImageUtil {
      * @param newWidth 前端指定的压缩宽,传递0,按照原图压缩，如果原图大于最大上线828,按照828比例压缩。
      */
     public static String zoomImage(Context context, Bitmap bitmap, int newWidth, int
-            biggestWidth, String filename) {
+            biggestWidth, int rotateDegree, String filename) {
 
         int width = bitmap.getWidth();
         int height = bitmap.getHeight();
@@ -110,6 +110,9 @@ public class ImageUtil {
         float scaleWidth = ((float) newWidth) / width;
         Matrix matrix = new Matrix();
         matrix.postScale(scaleWidth, scaleWidth);
+        if(rotateDegree != 0){
+            matrix.postRotate(rotateDegree); //修复EXIF旋转BUG
+        }
         Bitmap newBitmap = Bitmap.createBitmap(bitmap, 0, 0, width, height, matrix, true);
 
         return saveBitmap(newBitmap, filename, context);


### PR DESCRIPTION
修复EXIF照片旋转BUG，如果照片有EXIF旋转，程序无法正确处理，另还有eros-frame下的DefaultImageAdapter调用也需要处理